### PR TITLE
図と説明の不一致、リンク先の修正

### DIFF
--- a/docs/common/injection.md
+++ b/docs/common/injection.md
@@ -71,8 +71,8 @@ GraphQLサーバが受け取った入力をほかの処理系で利用する場�
 
 各インジェクション系の脆弱性の対策については、ここでの説明は省略します。各インジェクション系の脆弱性の対策について、より詳しい情報が必要であれば下記のようなページをご参照ください。
 
-- [OS Command Injection Prevention](https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html) [- OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
+- [OS Command Injection Defense - OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html)
 - [SQL Injection Prevention - OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
-- [NoSQL Injection](https://www.netsparker.com/blog/web-security/what-is-nosql-injection/) [- OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
-- [XXE Injection Prevention](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html) [- OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
+- [What is NoSQL Injection and How Can You Prevent It? | Invicti](https://www.netsparker.com/blog/web-security/what-is-nosql-injection/)
+- [XXE Injection Prevention - OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)
     - [XML Security - OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/cheatsheets/XML_Security_Cheat_Sheet.html)

--- a/docs/specific/dos.md
+++ b/docs/specific/dos.md
@@ -54,7 +54,7 @@ fragment teamFragment on Member {
 		teamId,
 		teamName,
 		memberList {
-			...memberFragment 
+			...memberFragment
 		}
 	}
 ```
@@ -102,11 +102,11 @@ query{
 
 データ構造をグラフ化することで、データどうしの関係を可視化し、解決がループしていないかを容易に探すことができます。
 
-"GraphQL Voyager"[2] はGraphQLのSDLやIntrospectionを読み込むことで、データ構造の関係図を作成するツールです。解決先のデータ構図を矢印で示します。
+"GraphQL Voyager"[2] はGraphQLのSDLやIntrospectionを読み込むことで、データ構造の関係図を作成するツールです。解決先のデータ構造を矢印で示します。
 
-![Untitled](dos/figure1.png)
+![図1.](dos/figure1.png)
 
-図1.は、GraphQL Voyagerのライブデモのスキーマを用いて作成したものです。PersonはStarshipオブジェクトを持っており、クエリ内に含まれている場合はStarshipも同時に解決されます。しかし、StarshipはPersonオブジェクトを持っており、双方でデータ構造の解決にループが生じていることが確認できます。
+図1.は、GraphQL Voyagerのライブデモのスキーマを用いて作成したものです。AuthorはBookオブジェクトを持っており、クエリ内に含まれている場合はBookも同時に解決されます。しかし、BookはAuthorオブジェクトを持っており、双方でデータ構造の解決にループが生じていることが確認できます。
 
 ### 解決をループさせるクエリの作成
 


### PR DESCRIPTION
説明内容が変わらない範囲で下記の修正を行いました。

DoS
- 「図1」の内容と本文とでオブジェクトの名称が一致していない点を図に合わせて修正
- typoの修正

Injection
- OS Command Injection、NoSQLi、XXEに張られたリンクの後半がSQLiのURLになっている点を修正
- OS Command Injectionのページタイトルが実際と異なる点を修正
- NoSQL Injectionのリンク先はOWASP Cheat Sheetではないため、正しいページタイトルに修正